### PR TITLE
Fixed collision event and added `-loader` suffix to worker

### DIFF
--- a/src/physi.js
+++ b/src/physi.js
@@ -388,7 +388,7 @@ module.exports = function (THREE) {
 		Eventable.call( this );
 		THREE.Scene.call( this );
 
-		var PhysijsWorker = require('worker!./physijs_worker.js');
+		var PhysijsWorker = require('worker-loader!./physijs_worker.js');
 		this._worker = new PhysijsWorker();
 		this._worker.transferableMessage = this._worker.webkitPostMessage || this._worker.postMessage;
 		this._materials_ref_counts = {};

--- a/src/physijs_worker.js
+++ b/src/physijs_worker.js
@@ -1252,8 +1252,19 @@ reportCollisions = function() {
 			pt = manifold.getContactPoint( j );
 			//if ( pt.getDistance() < 0 ) {
 				offset = 2 + (collisionreport[1]++) * COLLISIONREPORT_ITEMSIZE;
-				collisionreport[ offset ] = _objects_ammo[ manifold.getBody0() ];
-				collisionreport[ offset + 1 ] = _objects_ammo[ manifold.getBody1() ];
+
+				var body0 = manifold.getBody0();
+				if(typeof body0.ptr !== 'undefined'){
+                    body0 = body0.ptr;
+				}
+
+				var body1 = manifold.getBody1();
+				if (typeof body1.ptr !== 'undefined') {
+                    body1 = body1.ptr;
+				}
+
+				collisionreport[ offset ] = _objects_ammo[ body0 ];
+				collisionreport[ offset + 1 ] = _objects_ammo[ body1 ];
 
 				_vector = pt.get_m_normalWorldOnB();
 				collisionreport[ offset + 2 ] = _vector.x();


### PR DESCRIPTION
1) with newer version of webpack, `-loader` suffix is now mandatory.
`worker!...` => `worker-loader!...`

2) collision event were not fired anymore with the ammo version specified on that library. This fix is not breaking BC with older versions of ammo.