### PR TITLE
Add Travis CI support and README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+# default is apparently 0.10.48 for some reason O.O
+node_js: '8.9'

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # PhysiJS port for bundlers
 
+[//]: # (releases / versioning)
 [![package-json](https://img.shields.io/github/package-json/v/agilgur5/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 [![releases](https://img.shields.io/github/release/agilgur5/physijs-webpack.svg)](https://github.com/agilgur5/physijs-webpack/releases)
 [![commits](https://img.shields.io/github/commits-since/agilgur5/physijs-webpack/latest.svg)](https://github.com/agilgur5/physijs-webpack/commits/master)
 
+[//]: # (downloads)
 [![dt](https://img.shields.io/npm/dt/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 [![dy](https://img.shields.io/npm/dy/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 [![dm](https://img.shields.io/npm/dm/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 [![dw](https://img.shields.io/npm/dw/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 
+[//]: # (status / activity)
 [![build status](https://img.shields.io/travis/agilgur5/physijs-webpack.svg)](https://travis-ci.org/agilgur5/physijs-webpack)
 
 [![NPM](https://nodei.co/npm/physijs-webpack.png?downloads=true&downloadRank=true&stars=true)](https://npmjs.org/package/physijs-webpack)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![dm](https://img.shields.io/npm/dm/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 [![dw](https://img.shields.io/npm/dw/physijs-webpack.svg)](https://npmjs.org/package/physijs-webpack)
 
+[![build status](https://img.shields.io/travis/agilgur5/physijs-webpack.svg)](https://travis-ci.org/agilgur5/physijs-webpack)
+
 [![NPM](https://nodei.co/npm/physijs-webpack.png?downloads=true&downloadRank=true&stars=true)](https://npmjs.org/package/physijs-webpack)
 
 A [PhysiJS](https://github.com/chandlerprall/Physijs) port for bundlers with out-of-the-box support for Webpack and Browserify


### PR DESCRIPTION
- (ci): add Travis CI support
- (docs): add a Travis CI build badge
- (docs): add comments for what the badge sections are

Resolves #9 . Some potential problems arose on Node v10 LTS (I'm running v8 LTS locally) -- see the commit description in https://github.com/agilgur5/physijs-webpack/commit/7cb394b0cd026be396ed226e04d0f73a72c423e1 . Set it v8 and tests pass on Travis!

https://travis-ci.org/agilgur5/physijs-webpack